### PR TITLE
fix backtest assertion error 

### DIFF
--- a/src/opentrade/backtest.cc
+++ b/src/opentrade/backtest.cc
@@ -124,7 +124,7 @@ inline double Backtest::TryFillSell(double px, double qty, Orders* m) {
         << ',' << n << ',' << it->first << ',' << algo_id << '\n';
     if (tuple.leaves <= 0) {
       m->all.erase(tuple.order->id);
-      m->sells.erase(++it.base());
+      it = std::reverse_iterator(m->sells.erase(std::next(it).base()));
     } else {
       ++it;
     }


### PR DESCRIPTION
I was getting hit with a failed assertion at line 331 that tracks the invariant  all.size() == buys.size() + sells.size()
It took me a little while to track down the issue but I believe it breaks down for me when we try to erase from the sells map using the reverse iterator at line 127 in TryFillSell.  
The problem with the code as-written may be compiler/flags/platform dependent, but this change should work everywhere and it seemed to fix the issue for me.  
